### PR TITLE
Require the ASTRA-Toolbox version 2.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ build:
   variables:
   script:
     - conda install -yq conda-build conda-verify
-    - conda build conda/ -c defaults -c astra-toolbox/label/dev
+    - conda build conda/ -c defaults -c astra-toolbox
     - mkdir -p artifacts
     - mv /opt/conda/conda-bld/noarch/tomosipo*.tar.bz2 artifacts/
   artifacts:
@@ -61,7 +61,7 @@ pages:
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O install_conda.sh
     - bash install_conda.sh -b
     - export PATH="$HOME/miniconda3/bin:$PATH"
-    - conda install python=3.7 cudatoolkit=9.2 astra-toolbox pyqtgraph pyqt pyopengl pytorch ffmpeg ffmpeg-python matplotlib sphinx ipython sphinx_rtd_theme recommonmark -c defaults -c astra-toolbox/label/dev -c conda-forge -yq
+    - conda install python=3.7 cudatoolkit=9.2 astra-toolbox pyqtgraph pyqt pyopengl pytorch ffmpeg ffmpeg-python matplotlib sphinx ipython sphinx_rtd_theme recommonmark -c defaults -c astra-toolbox -c conda-forge -yq
     - pip install .[dev]
     - sphinx-apidoc -M -f -e --tocfile api_reference -H "API Reference" --ext-autodoc -o doc/ref/ tomosipo
     - sphinx-build -b html doc/ public

--- a/README.md
+++ b/README.md
@@ -37,33 +37,21 @@ The documentation can be found [here](https://aahendriksen.gitlab.io/tomosipo/in
 A minimal installation requires:
 
 -   python >= 3.6
--   ASTRA-toolbox (the latest 1.9.x development version is **required**)
+-   ASTRA-toolbox >= 2.0
 -   CUDA
 
-These requirements can be installed using conda (replace `<X.X>` by your
-CUDA version)
+The requirements can be installed using the anaconda package manager. The
+following snippet creates a new conda environment named `tomosipo` (replace
+`X.X` by your CUDA version)
 
-    conda create -y -n tomosipo python=3.8 astra-toolbox cudatoolkit=<X.X> -c astra-toolbox/label/dev
-    pip install git+https://github.com/ahendriksen/tomosipo@develop
-    source activate tomosipo
+    conda create -n tomosipo cudatoolkit=<X.X> tomosipo -c defaults -c astra-toolbox -c aahendriksen
 
-To use tomosipo with PyTorch, QT, ODL, and cupy, install:
-
-    conda create -y -n tomosipo python=3.8 astra-toolbox cudatoolkit=<X.X> pytorch cupy pyqtgraph pyqt pyopengl cupy \
-          -c defaults -c astra-toolbox/label/dev -c pytorch -c conda-forge
-    source activate tomosipo
-    # Install latest version of ODL:
-    pip install git+https://github.com/odlgroup/odl
-    # Install development version of tomosipo:
-    pip install git+https://github.com/ahendriksen/tomosipo@develop
-
+More information about installation is provided in the [documentation](https://aahendriksen.gitlab.io/tomosipo/intro/install.html).
 
 <a id="orgb723de1"></a>
-
 # Usage
 
 Simple examples:
-
 
 <a id="org887ab1a"></a>
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,13 +23,13 @@ build:
 requirements:
     host:
         - python >=3.6
-        - astra-toolbox
+        - astra-toolbox >=2.0
         - setuptools
         - pytest-runner
 
     run:
         - python >=3.6
-        - astra-toolbox
+        - astra-toolbox >=2.0
 
 about:
     home: https://github.com/ahendriksen/tomosipo

--- a/doc/intro/install.rst
+++ b/doc/intro/install.rst
@@ -4,7 +4,7 @@ Install tomosipo
 A minimal installation requires:
 
 * python >= 3.6
-* ASTRA-toolbox (the latest 1.9.x development version is *required*)
+* ASTRA-toolbox >= 2.0
 * CUDA
 
 Installation using anaconda
@@ -16,7 +16,7 @@ following snippet creates a new conda environment named `tomosipo` (replace
 
 .. code-block:: bash
 
-   conda create -n tomosipo cudatoolkit=<X.X> tomosipo -c defaults -c astra-toolbox/label/dev -c aahendriksen
+   conda create -n tomosipo cudatoolkit=<X.X> tomosipo -c defaults -c astra-toolbox -c aahendriksen
 
 
 Install the latest development branch
@@ -27,7 +27,7 @@ environment named `tomosipo` containing the required packages:
 
 .. code-block:: bash
 
-    conda create -n tomosipo python=3.8 astra-toolbox cudatoolkit=X.X -c astra-toolbox/label/dev
+    conda create -n tomosipo python=3.8 astra-toolbox cudatoolkit=X.X -c astra-toolbox
 
 Then activate the environment and install tomosipo using pip:
 
@@ -44,7 +44,7 @@ To use tomosipo with PyTorch, QT, ODL, and cupy, install:
 .. code-block:: bash
 
     conda create -n tomosipo tomosipo cudatoolkit=<X.X> pytorch cupy pyqtgraph pyqt pyopengl cupy \
-                 -c defaults -c astra-toolbox/label/dev -c pytorch -c conda-forge -c aahendriksen
+                 -c defaults -c astra-toolbox -c pytorch -c conda-forge -c aahendriksen
     source activate tomosipo
     # Install latest version of ODL:
     pip install git+https://github.com/odlgroup/odl
@@ -58,4 +58,4 @@ To just install PyTorch, use
 
 .. code-block:: bash
 
-   conda create -n tomosipo pytorch cudatoolkit=<X.X> tomosipo -c defaults -c astra-toolbox/label/dev -c aahendriksen -c pytorch
+   conda create -n tomosipo pytorch cudatoolkit=<X.X> tomosipo -c defaults -c astra-toolbox -c aahendriksen -c pytorch

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.md') as readme_file:
 #     history = history_file.read()
 
 requirements = [
-    'astra-toolbox',
+    'astra-toolbox>=2.0',
     'numpy',
 ]
 

--- a/tomosipo/__init__.py
+++ b/tomosipo/__init__.py
@@ -52,14 +52,14 @@ try:
 except AttributeError:
     raise ImportError(
         "Cannot find all required astra.experimental methods. \n"
-        "Please make sure you have at least ASTRA version 1.9.9-dev4 installed. \n"
-        "You can install the latest ASTRA development version using: \n"
-        "> conda install astra-toolbox -c astra-toolbox/label/dev "
+        "Please make sure you have at least ASTRA version 2.0 installed. \n"
+        "You can install the latest ASTRA version using: \n"
+        "> conda install astra-toolbox=2.0 -c astra-toolbox "
     )
 except ImportError:
     raise ImportError(
         "Cannot find all required astra.experimental methods. \n"
-        "Please make sure you have at least ASTRA version 1.9.9-dev4 installed. \n"
-        "You can install the latest ASTRA development version using: \n"
-        "> conda install astra-toolbox -c astra-toolbox/label/dev "
+        "Please make sure you have at least ASTRA version 2.0 installed. \n"
+        "You can install the latest ASTRA version using: \n"
+        "> conda install astra-toolbox=2.0 -c astra-toolbox "
     )


### PR DESCRIPTION
This PR

- Adds a dependency on astra-toolbox version > 2 in setup.py
-  Adds a dependency on astra-toolbox version > 2 in the conda metadata
- Describes installation of astra-toolbox version 2 without references to the development channel on Conda.

This should simplify installation.

I have not tested this PR. 