### PR TITLE
add default_camera() scale option

### DIFF
--- a/tomosipo/svg.py
+++ b/tomosipo/svg.py
@@ -155,7 +155,7 @@ def pg_to_line_items(pg, i):
 # the source. The cone angle determines the field of view.
 
 
-def default_camera(height, width, angle=1 / 2.7):
+def default_camera(height, width, angle=1 / 2.7, scale=1):
     # default camera:
     R0 = ts.rotate(pos=0, axis=(1, 0, 0), angles=np.deg2rad(70))
     R1 = ts.rotate(pos=0, axis=(0, 0, 1), angles=np.deg2rad(-25))
@@ -164,7 +164,7 @@ def default_camera(height, width, angle=1 / 2.7):
     good_cone = (
         R0 * R1 * ts.cone(cone_angle=angle, shape=(height, width), size=size).to_vec()
     )
-    camera = ts.translate(good_cone.src_pos * 10 * angle) * good_cone
+    camera = ts.translate(good_cone.src_pos * 10 * scale * angle) * good_cone
 
     return camera
 


### PR DESCRIPTION
I'm using tomosipo in a remote sensing context where the volume cube being observed (Earth's atmosphere) is millions of physical units per side.

This is a simple change that allows us to scale the default camera location when generating SVG animations.

``` python
svg = ts.svg(
    volume,
    geom,
    height=height, width=width,
    camera=default_camera(height, width, scale=max(volume.size))
)
```

Perhaps at some point `tomosipo.svg.svg()` should try to compute a good default camera location based on `*geoms`.