### PR TITLE
Fix error message in assert in OperatorFunction

### DIFF
--- a/tomosipo/torch_support.py
+++ b/tomosipo/torch_support.py
@@ -33,7 +33,7 @@ class OperatorFunction(Function):
         assert (
             input.ndim == expected_ndim
         ), (f"Tomosipo autograd operator expected {expected_ndim} dimensions "
-        "but got {input.ndim}.\n"
+        f"but got {input.ndim}.\n"
         "The interface of to_autograd was changed in Tomosipo 0.6.0 to "
         "by default match standard Tomosipo operators and extra arguments are "
         "provided to match Pytorch NN functions.\n"


### PR DESCRIPTION
When using an `OperatorFunction` from `tomosipo.torch_support`, and inputting a tensor with the wrong number of dimensions, the current message in the assertion does not show the `input.ndim` properly because it is not in an f-string. This pull request fixes the issue.

![Screenshot 2023-10-02 at 13 06 48](https://github.com/ahendriksen/tomosipo/assets/12610714/dab354e3-c87a-49ed-aa96-f0434ccc7f9f)
