### PR TITLE
Use GPULink from astra.pythonutils module instead of astra.data3d

### DIFF
--- a/tomosipo/links/torch.py
+++ b/tomosipo/links/torch.py
@@ -95,7 +95,7 @@ class TorchLink(Link):
         if self._data.is_cuda:
             z, y, x = self._data.shape
             pitch = x * 4  # we assume 4 byte float32 values
-            link = astra.data3d.GPULink(self._data.data_ptr(), x, y, z, pitch)
+            link = astra.pythonutils.GPULink(self._data.data_ptr(), x, y, z, pitch)
             return link
         else:
             # The torch tensor may be part of the computation


### PR DESCRIPTION
Using astra 2.3, tomosipo's projection operator using pytorch does not work because it's trying to use `astra.data3d.GPULink`. In fact, this method was in astra.pythonutils module before too, but you could import it via data3d until they removed that import in the data3d module in this commit (https://github.com/astra-toolbox/astra-toolbox/commit/2db5b7038cdfc0ae139b6c7ef1af65c2245a51fc#diff-a6823def1fec828957f87f3f82de0c60367da5478305797e8f4fd4d9bd0c7c4a).