### PR TITLE
Add NumPy 2 compatibility

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     run:
         - python >=3.6
         - astra-toolbox >=2.0
+        - numpy >=1.21
 
 about:
     home: https://github.com/ahendriksen/tomosipo

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md') as readme_file:
 
 requirements = [
     'astra-toolbox>=2.0',
-    'numpy',
+    'numpy>=1.21',
 ]
 
 setup_requirements = [

--- a/tomosipo/geometry/det_vec.py
+++ b/tomosipo/geometry/det_vec.py
@@ -104,14 +104,15 @@ class DetectorVectorGeometry(ProjectionGeometry):
         self._is_vector = True
 
     def __repr__(self):
-        return (
-            f"DetectorVectorGeometry(\n"
-            f"    shape={self.det_shape},\n"
-            f"    det_pos={self._det_pos},\n"
-            f"    det_u={self._det_v},\n"
-            f"    det_v={self._det_u}"
-            f")"
-        )
+        with ts.utils.print_options():
+            return (
+                f"DetectorVectorGeometry(\n"
+                f"    shape={self.det_shape},\n"
+                f"    det_pos={self._det_pos},\n"
+                f"    det_u={self._det_v},\n"
+                f"    det_v={self._det_u}"
+                f")"
+            )
 
     def __eq__(self, other):
         if not isinstance(other, DetectorVectorGeometry):

--- a/tomosipo/geometry/transform.py
+++ b/tomosipo/geometry/transform.py
@@ -52,7 +52,8 @@ class Transform(object):
             return NotImplemented
 
     def __repr__(self):
-        return f"Transform(\n" f"    {self.matrix}\n" f")"
+        with ts.utils.print_options():
+            return f"Transform(\n" f"    {self.matrix}\n" f")"
 
     def __eq__(self, other):
         if not isinstance(other, Transform):

--- a/tomosipo/geometry/volume.py
+++ b/tomosipo/geometry/volume.py
@@ -226,13 +226,14 @@ class VolumeGeometry:
         np.array(self._inner.size)
 
     def __repr__(self):
-        return (
-            f"ts.volume(\n"
-            f"    shape={self._inner.shape},\n"
-            f"    pos={tuple(self.pos[0])},\n"
-            f"    size={self.size},\n"
-            f")"
-        )
+        with ts.utils.print_options():
+            return (
+                f"ts.volume(\n"
+                f"    shape={self._inner.shape},\n"
+                f"    pos={tuple(self.pos[0])},\n"
+                f"    size={self.size},\n"
+                f")"
+            )
 
     def __eq__(self, other):
         # TODO: Consider VolumeVectorGeometries...

--- a/tomosipo/links/numpy.py
+++ b/tomosipo/links/numpy.py
@@ -16,7 +16,7 @@ class NumpyLink(Link):
             self._data = np.zeros(shape, dtype=np.float32)
             self._data[:] = initial_value
         else:
-            initial_value = np.array(initial_value, copy=False)
+            initial_value = np.asarray(initial_value)
             if initial_value.shape != shape:
                 raise ValueError(
                     "Cannot link array. "

--- a/tomosipo/svg.py
+++ b/tomosipo/svg.py
@@ -76,7 +76,7 @@ def line_item(pos, width=1, color=(0.0, 0.0, 0.0, 1.0)):
 
     """
 
-    pos = np.array(pos, dtype=np.float64, copy=False)
+    pos = np.asarray(pos, dtype=np.float64)
     assert pos.ndim == 2
     assert pos.shape[1] == 3
 

--- a/tomosipo/types.py
+++ b/tomosipo/types.py
@@ -276,7 +276,8 @@ def to_scalars(s: ToScalars, var_name="scalars", accept_empty=False) -> Scalars:
     TypeError: Could not convert to array of scalars: array contains NaN.
     """
     try:
-        s = np.array(s, dtype=np.float64, ndmin=1, copy=False)
+        s = np.asarray(s, dtype=np.float64)
+        s = ts.utils.atleast_nd(s, ndmin=1)
     except ValueError:
         raise TypeError(f"Could not convert {var_name} to np.array. Got: {repr(s)}.")
     if np.any(np.isnan(s)):
@@ -330,11 +331,11 @@ def to_vec(vec: ToVec, var_name="vector") -> Vec:
     TypeError: Could not convert vector to np.array. Got: 'string'.
     """
     try:
-        vec = np.array(vec, dtype=np.float64, copy=False)
+        vec = np.asarray(vec, dtype=np.float64)
     except ValueError:
         raise TypeError(f"Could not convert {var_name} to np.array. Got: {repr(vec)}.")
     shape = vec.shape
-    vec = np.array(vec, dtype=np.float64, copy=False, ndmin=2)
+    vec = ts.utils.atleast_nd(vec, ndmin=2)
 
     if vec.ndim == 2 and vec.shape[1] == 3:
         return vec
@@ -352,11 +353,11 @@ def to_homogeneous(vec, s) -> HomogeneousVec:
     """
     s = float(s)
     try:
-        vec = np.array(vec, dtype=np.float64, copy=False)
+        vec = np.asarray(vec, dtype=np.float64)
     except ValueError:
         raise TypeError(f"Could not convert value to np.array. Got: {repr(vec)}.")
     shape = vec.shape
-    vec = np.array(vec, dtype=np.float64, copy=False, ndmin=2)
+    vec = ts.utils.atleast_nd(vec, ndmin=2)
 
     if vec.ndim == 2:
         if vec.shape[1] == 4:

--- a/tomosipo/utils.py
+++ b/tomosipo/utils.py
@@ -28,7 +28,7 @@ def print_options():
         infstr="inf",
         sign="-",
         formatter=None,
-        legacy=False,
+        legacy='1.21',
     )
 
 

--- a/tomosipo/utils.py
+++ b/tomosipo/utils.py
@@ -117,3 +117,13 @@ def slice_interval(left, right, length, key):
 
     # Prevent division by zero
     return (L, R, new_len, new_pixel_size)
+
+
+def atleast_nd(array, ndmin):
+    """View input as array with at least `ndmin` dimensions.
+    
+    This is different from numpy.atleast_1d/2d in that it prepends
+    dimensions instead of appending them.
+
+    """
+    return np.array(array, ndmin=ndmin, copy=False)

--- a/tomosipo/vector_calc.py
+++ b/tomosipo/vector_calc.py
@@ -28,9 +28,9 @@ from contextlib import contextmanager
 
 
 def to_vec(x):
-    x = np.array(x, dtype=np.float64, copy=False)
+    x = np.asarray(x, dtype=np.float64)
     s = x.shape
-    x = np.array(x, dtype=np.float64, copy=False, ndmin=2)
+    x = ts.utils.atleast_nd(x, ndmin=2)
 
     if x.ndim == 2 and x.shape[1] == 3:
         return x
@@ -44,9 +44,9 @@ def to_vec(x):
 
 
 def to_scalar(x):
-    x = np.array(x, dtype=np.float64, copy=False)
+    x = np.asarray(x, dtype=np.float64)
     s = x.shape
-    x = np.array(x, dtype=np.float64, copy=False, ndmin=1)
+    x = ts.utils.atleast_nd(x, ndmin=1)
 
     if x.ndim == 1:
         # Add a single dimension to the right. Note that `to_vec` adds
@@ -98,8 +98,8 @@ def broadcast_lengths(len_a, len_b):
 
 
 def _broadcastv(x, y):
-    x = np.array(x, copy=False)
-    y = np.array(y, copy=False)
+    x = np.asarray(x)
+    y = np.asarray(y)
     # Save original shapes for error messages later.
     s1, s2 = x.shape, y.shape
     # Add dimensions, if necessary:
@@ -120,7 +120,7 @@ def _broadcastv(x, y):
 
 
 def _broadcastmv(M, x):
-    M, x = np.array(M, copy=False), np.array(x, copy=False)
+    M, x = np.asarray(M), np.asarray(x)
     # Save original shapes for error messages later.
     s1, s2 = M.shape, x.shape
 
@@ -146,8 +146,8 @@ def _broadcastmv(M, x):
 
 
 def _broadcastmm(M1, M2):
-    M1 = np.array(M1, copy=False)
-    M2 = np.array(M2, copy=False)
+    M1 = np.asarray(M1)
+    M2 = np.asarray(M2)
     # Save original shapes for error messages
     s1 = M1.shape
     s2 = M2.shape


### PR DESCRIPTION
This PR fixes issues due to `np.array` copy semantics and scalar array print formatting changes in NumPy 2. The minimum requirement for NumPy is increased to 1.21.