### PR TITLE
Fix slicing vector geometries with negative steps

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,3 +112,20 @@ def test_slice_interval():
     assert st[1::3].center == approx(st.center)
     assert st[0::3].center != approx(st.center)
     assert st[2::3].center != approx(st.center)
+
+
+def test_slice_interval_negative_step():
+    # Reversing the interval keeps the number of pixels; size and
+    # pixel_size pick up the sign of the step (R < L for a negative step)
+    st = Interval(0, 8, 8)
+    assert st[::-1].length == 8
+    assert st[::-1].size == approx(-8.0)
+    assert st[::-1].pixel_size == approx(-1.0)
+
+    # Check that length is consistent with np indexing:
+    for length in [1, 2, 5]:
+        st = Interval(0, 1, length)
+        ones = np.ones(length)
+        for step in [-1, -2, -3]:
+            assert st[::step].length == len(ones[::step])
+            assert st[::step].pixel_size == approx(step * st.pixel_size)

--- a/tomosipo/utils.py
+++ b/tomosipo/utils.py
@@ -108,12 +108,12 @@ def slice_interval(left, right, length, key):
     start, stop, step = key.indices(length)
     # `(stop - start)` is not necessarily divisible by `step`. We have
     # to calculate new_len in this convoluted way:
-    new_len = max(0, (stop - start + step - 1) // step)
-    stop = max(start, start + (new_len - 1) * step + 1)
+    new_len = max(0, (stop - start + step - (1 if step > 0 else -1)) // step)
+    last_idx = start + (new_len - 1) * step
 
     new_pixel_size = pixel_size * step
     L = left + start * pixel_size + 0.5 * pixel_size * (1 - step)
-    R = left + stop * pixel_size + 0.5 * pixel_size * (step - 1)
+    R = left + last_idx * pixel_size + 0.5 * pixel_size * (step + 1)
 
     # Prevent division by zero
     return (L, R, new_len, new_pixel_size)


### PR DESCRIPTION
I'm learning XCT reconstruction algorithms and have been going through tomosipo's source to understand vector geometries. While testing reverse slicing (`pg.to_vec()[:, ::-1, :]` / `vg.to_vec()[:, ::-1, :, :]`) I found it silently disagrees with numpy indexing: an 8-pixel detector becomes 10 pixels and gets shifted, with no error raised. Since reverse indexing is a natural thing to try, this gives wrong geometries (and thus shifted backprojections) without any warning.

`slice_interval` assumes a positive step. I made the formulas handle negative steps. With step=-1, reversing an 8-pixel interval now returns (8, 0, 8, -1.0) instead of (8, 6, 10, -1.0). I verified the results against numpy indexing over a bunch of negative-step cases; positive-step behavior is unchanged.
