### PR TITLE
Fix VolumeVectorGeometry.reshape

### DIFF
--- a/tests/geometry/test_volume_vec.py
+++ b/tests/geometry/test_volume_vec.py
@@ -141,6 +141,14 @@ def test_get_item():
         vg[1, 2, 3, 4, 5]
 
 
+def test_reshape(vg):
+    assert vg.reshape(1).shape == (1, 1, 1)
+    assert vg.reshape((3, 5, 7)).shape == (3, 5, 7)
+
+    assert vg.reshape(1).sizes == approx(vg.sizes)
+    assert vg.reshape((3, 5, 7)).sizes == approx(vg.sizes)
+
+
 def test_size():
     vg = ts.geometry.random_volume().to_vec()
     # Non-uniform scaling

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,3 +112,20 @@ def test_slice_interval():
     assert st[1::3].center == approx(st.center)
     assert st[0::3].center != approx(st.center)
     assert st[2::3].center != approx(st.center)
+
+
+def test_slice_interval_negative_step():
+    # Reversing the interval keeps the number of pixels; size and
+    # pixel_size pick up the sign of the step (R < L for a negative step)
+    st = Interval(0, 8, 8)
+    assert st[::-1].length == 8
+    assert st[::-1].size == approx(-8.0)
+    assert st[::-1].pixel_size == approx(-1.0)
+
+    # Check that length is consistent with np indexing:
+    for length in [1, 2, 5]:
+        st = Interval(0, 1, length)
+        ones = np.ones(length)
+        for step in [-1, -2, -3]:
+            assert st[::step].length == len(ones[::step])
+            assert st[::step].pixel_size == approx(step * st.pixel_size)

--- a/tomosipo/geometry/volume_vec.py
+++ b/tomosipo/geometry/volume_vec.py
@@ -411,9 +411,9 @@ class VolumeVectorGeometry(object):
 
         """
         new_shape = ts.types.to_shape3d(new_shape)
-        new_w = self.sizes[:, 0] / max(new_shape[0], 1)
-        new_v = self.sizes[:, 1] / max(new_shape[1], 1)
-        new_u = self.sizes[:, 2] / max(new_shape[2], 1)
+        new_w = self.w / max(new_shape[0], 1) * self.shape[0]
+        new_v = self.v / max(new_shape[1], 1) * self.shape[1]
+        new_u = self.u / max(new_shape[2], 1) * self.shape[2]
 
         return VolumeVectorGeometry(
             new_shape,

--- a/tomosipo/utils.py
+++ b/tomosipo/utils.py
@@ -108,12 +108,12 @@ def slice_interval(left, right, length, key):
     start, stop, step = key.indices(length)
     # `(stop - start)` is not necessarily divisible by `step`. We have
     # to calculate new_len in this convoluted way:
-    new_len = max(0, (stop - start + step - 1) // step)
-    stop = max(start, start + (new_len - 1) * step + 1)
+    new_len = max(0, (stop - start + step - (1 if step > 0 else -1)) // step)
+    last_idx = start + (new_len - 1) * step
 
     new_pixel_size = pixel_size * step
     L = left + start * pixel_size + 0.5 * pixel_size * (1 - step)
-    R = left + stop * pixel_size + 0.5 * pixel_size * (step - 1)
+    R = left + last_idx * pixel_size + 0.5 * pixel_size * (step + 1)
 
     # Prevent division by zero
     return (L, R, new_len, new_pixel_size)


### PR DESCRIPTION
Thanks for maintaining tomosipo - I've been learning XCT reconstruction algorithms and reading through the geometry code has been really helpful.

I tried calling `VolumeVectorGeometry.reshape` and it always raises a `TypeError`: it passes `self.sizes[:, i]` (shape `(num_steps,)`) as the w/v/u arguments, but `to_vec` only accepts `(3,)` or `(N, 3)`. I reshaped the w/v/u direction vectors directly instead, the same way `DetectorVectorGeometry.reshape` does. `sizes` is preserved and the voxel directions are unchanged. Please let me know if I'm missing something.
